### PR TITLE
Correct rule name in options example

### DIFF
--- a/docs/rules/no-dead-code.md
+++ b/docs/rules/no-dead-code.md
@@ -83,7 +83,7 @@ The rule takes a single, optional, options object with the properties and defaul
 ```js
 {
     "rules": {
-        "pocket-fluff/no-jsx-spread": [
+        "pocket-fluff/no-dead-code": [
             "error", 
             {
                 "currentEpochTimeMS": Date.now(), // For testing or decoupling from system time. 


### PR DESCRIPTION
Belive that there is a wrong reference to `no-jsx-spread` in line 86, that should say `no-dead-code`